### PR TITLE
Upgrade dependencies all around

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
 # moor_shared
 
-An example project to demonstrate how moor can be used on multiple platforms
+An example project to demonstrate how drift (formerly known as moor) can be used on multiple platforms
 (Web, android, iOS, macOS, Windows and Linux).
-
-__Note__: You need to install the Android NDK to run this app on Android
-devices. You can get the NDK in the [SDK Manager](https://developer.android.com/studio/intro/update.html#sdk-manager)
-of Android Studio.
 
 - Undo/Redo
 - Cross Platform
@@ -33,8 +29,19 @@ samples, guidance on mobile development, and a full API reference.
 
 ### Windows
 
+__Note__: On Linux and Windows, you need to ensure that the compiled native sqlite3 libraries
+are available as a `.so` or a `.dll`, respectively.
+The `sqlite3_flutter_libs` package only automates this process for Android, iOS and macOS.
+For more information on how to setup drift on all platforms, see [this page](https://drift.simonbinder.eu/docs/platforms/).
+As shown in [this commit](https://github.com/rodydavis/moor_shared/commit/32bf6823e2d260ea449c2c4ae37eab212f2e7939),
+sqlite3 is bundled natively in this example.
+
 ![](/screenshots/windows.png)
 
 ### Web
+
+__Note__: When launching the app in debug mode on Chrome, Flutter will use a
+temporary user profile which doesn't persist data across debug sessions.
+Release builds aren't affected by this.
 
 ![](/screenshots/web.png)

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="moor_shared"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.1-all.zip

--- a/lib/plugins/desktop/io.dart
+++ b/lib/plugins/desktop/io.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 
 void setTargetPlatformForDesktop({TargetPlatform? platform}) {
   TargetPlatform? targetPlatform;

--- a/lib/src/blocs/todo.dart
+++ b/lib/src/blocs/todo.dart
@@ -1,5 +1,5 @@
 import 'package:bloc/bloc.dart';
-import 'package:moor/moor.dart';
+import 'package:drift/drift.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:undo/undo.dart';
 

--- a/lib/src/database/database.dart
+++ b/lib/src/database/database.dart
@@ -1,5 +1,5 @@
 // don't import moor_web.dart or moor_flutter/moor_flutter.dart in shared code
-import 'package:moor/moor.dart';
+import 'package:drift/drift.dart';
 import 'package:undo/undo.dart';
 
 import 'db_utils.dart';
@@ -43,7 +43,7 @@ class EntryWithCategory {
   final Category? category;
 }
 
-@UseMoor(
+@DriftDatabase(
   tables: [Todos, Categories],
   queries: {
     '_resetCategory': 'UPDATE todos SET category = NULL WHERE category = ?',
@@ -107,7 +107,7 @@ class Database extends _$Database {
       final hasId = row.data['id'] != null;
 
       return CategoryWithCount(
-        hasId ? Category.fromData(row.data, this) : null,
+        hasId ? Category.fromData(row.data) : null,
         row.read<int>('amount'),
       );
     }).watch();

--- a/lib/src/database/database.g.dart
+++ b/lib/src/database/database.g.dart
@@ -17,8 +17,7 @@ class TodoEntry extends DataClass implements Insertable<TodoEntry> {
       required this.content,
       this.targetDate,
       this.category});
-  factory TodoEntry.fromData(Map<String, dynamic> data, GeneratedDatabase db,
-      {String? prefix}) {
+  factory TodoEntry.fromData(Map<String, dynamic> data, {String? prefix}) {
     final effectivePrefix = prefix ?? '';
     return TodoEntry(
       id: const IntType()
@@ -60,7 +59,7 @@ class TodoEntry extends DataClass implements Insertable<TodoEntry> {
 
   factory TodoEntry.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
-    serializer ??= moorRuntimeOptions.defaultSerializer;
+    serializer ??= driftRuntimeOptions.defaultSerializer;
     return TodoEntry(
       id: serializer.fromJson<int>(json['id']),
       content: serializer.fromJson<String>(json['content']),
@@ -70,7 +69,7 @@ class TodoEntry extends DataClass implements Insertable<TodoEntry> {
   }
   @override
   Map<String, dynamic> toJson({ValueSerializer? serializer}) {
-    serializer ??= moorRuntimeOptions.defaultSerializer;
+    serializer ??= driftRuntimeOptions.defaultSerializer;
     return <String, dynamic>{
       'id': serializer.toJson<int>(id),
       'content': serializer.toJson<String>(content),
@@ -99,8 +98,7 @@ class TodoEntry extends DataClass implements Insertable<TodoEntry> {
   }
 
   @override
-  int get hashCode => $mrjf($mrjc(id.hashCode,
-      $mrjc(content.hashCode, $mrjc(targetDate.hashCode, category.hashCode))));
+  int get hashCode => Object.hash(id, content, targetDate, category);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -186,55 +184,40 @@ class TodosCompanion extends UpdateCompanion<TodoEntry> {
 }
 
 class $TodosTable extends Todos with TableInfo<$TodosTable, TodoEntry> {
-  final GeneratedDatabase _db;
+  @override
+  final GeneratedDatabase attachedDatabase;
   final String? _alias;
-  $TodosTable(this._db, [this._alias]);
+  $TodosTable(this.attachedDatabase, [this._alias]);
   final VerificationMeta _idMeta = const VerificationMeta('id');
   @override
-  late final GeneratedIntColumn id = _constructId();
-  GeneratedIntColumn _constructId() {
-    return GeneratedIntColumn('id', $tableName, false,
-        hasAutoIncrement: true, declaredAsPrimaryKey: true);
-  }
-
+  late final GeneratedColumn<int?> id = GeneratedColumn<int?>(
+      'id', aliasedName, false,
+      type: const IntType(),
+      requiredDuringInsert: false,
+      defaultConstraints: 'PRIMARY KEY AUTOINCREMENT');
   final VerificationMeta _contentMeta = const VerificationMeta('content');
   @override
-  late final GeneratedTextColumn content = _constructContent();
-  GeneratedTextColumn _constructContent() {
-    return GeneratedTextColumn(
-      'content',
-      $tableName,
-      false,
-    );
-  }
-
+  late final GeneratedColumn<String?> content = GeneratedColumn<String?>(
+      'content', aliasedName, false,
+      type: const StringType(), requiredDuringInsert: true);
   final VerificationMeta _targetDateMeta = const VerificationMeta('targetDate');
   @override
-  late final GeneratedDateTimeColumn targetDate = _constructTargetDate();
-  GeneratedDateTimeColumn _constructTargetDate() {
-    return GeneratedDateTimeColumn(
-      'target_date',
-      $tableName,
-      true,
-    );
-  }
-
+  late final GeneratedColumn<DateTime?> targetDate = GeneratedColumn<DateTime?>(
+      'target_date', aliasedName, true,
+      type: const IntType(), requiredDuringInsert: false);
   final VerificationMeta _categoryMeta = const VerificationMeta('category');
   @override
-  late final GeneratedIntColumn category = _constructCategory();
-  GeneratedIntColumn _constructCategory() {
-    return GeneratedIntColumn('category', $tableName, true,
-        $customConstraints: 'NULLABLE REFERENCES categories(id)');
-  }
-
+  late final GeneratedColumn<int?> category = GeneratedColumn<int?>(
+      'category', aliasedName, true,
+      type: const IntType(),
+      requiredDuringInsert: false,
+      $customConstraints: 'NULLABLE REFERENCES categories(id)');
   @override
   List<GeneratedColumn> get $columns => [id, content, targetDate, category];
   @override
-  $TodosTable get asDslTable => this;
+  String get aliasedName => _alias ?? 'todos';
   @override
-  String get $tableName => _alias ?? 'todos';
-  @override
-  final String actualTableName = 'todos';
+  String get actualTableName => 'todos';
   @override
   VerificationContext validateIntegrity(Insertable<TodoEntry> instance,
       {bool isInserting = false}) {
@@ -266,13 +249,13 @@ class $TodosTable extends Todos with TableInfo<$TodosTable, TodoEntry> {
   Set<GeneratedColumn> get $primaryKey => {id};
   @override
   TodoEntry map(Map<String, dynamic> data, {String? tablePrefix}) {
-    return TodoEntry.fromData(data, _db,
+    return TodoEntry.fromData(data,
         prefix: tablePrefix != null ? '$tablePrefix.' : null);
   }
 
   @override
   $TodosTable createAlias(String alias) {
-    return $TodosTable(_db, alias);
+    return $TodosTable(attachedDatabase, alias);
   }
 }
 
@@ -280,8 +263,7 @@ class Category extends DataClass implements Insertable<Category> {
   final int id;
   final String? description;
   Category({required this.id, this.description});
-  factory Category.fromData(Map<String, dynamic> data, GeneratedDatabase db,
-      {String? prefix}) {
+  factory Category.fromData(Map<String, dynamic> data, {String? prefix}) {
     final effectivePrefix = prefix ?? '';
     return Category(
       id: const IntType()
@@ -311,7 +293,7 @@ class Category extends DataClass implements Insertable<Category> {
 
   factory Category.fromJson(Map<String, dynamic> json,
       {ValueSerializer? serializer}) {
-    serializer ??= moorRuntimeOptions.defaultSerializer;
+    serializer ??= driftRuntimeOptions.defaultSerializer;
     return Category(
       id: serializer.fromJson<int>(json['id']),
       description: serializer.fromJson<String?>(json['description']),
@@ -319,7 +301,7 @@ class Category extends DataClass implements Insertable<Category> {
   }
   @override
   Map<String, dynamic> toJson({ValueSerializer? serializer}) {
-    serializer ??= moorRuntimeOptions.defaultSerializer;
+    serializer ??= driftRuntimeOptions.defaultSerializer;
     return <String, dynamic>{
       'id': serializer.toJson<int>(id),
       'description': serializer.toJson<String?>(description),
@@ -340,7 +322,7 @@ class Category extends DataClass implements Insertable<Category> {
   }
 
   @override
-  int get hashCode => $mrjf($mrjc(id.hashCode, description.hashCode));
+  int get hashCode => Object.hash(id, description);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -401,37 +383,29 @@ class CategoriesCompanion extends UpdateCompanion<Category> {
 
 class $CategoriesTable extends Categories
     with TableInfo<$CategoriesTable, Category> {
-  final GeneratedDatabase _db;
+  @override
+  final GeneratedDatabase attachedDatabase;
   final String? _alias;
-  $CategoriesTable(this._db, [this._alias]);
+  $CategoriesTable(this.attachedDatabase, [this._alias]);
   final VerificationMeta _idMeta = const VerificationMeta('id');
   @override
-  late final GeneratedIntColumn id = _constructId();
-  GeneratedIntColumn _constructId() {
-    return GeneratedIntColumn('id', $tableName, false,
-        hasAutoIncrement: true, declaredAsPrimaryKey: true);
-  }
-
+  late final GeneratedColumn<int?> id = GeneratedColumn<int?>(
+      'id', aliasedName, false,
+      type: const IntType(),
+      requiredDuringInsert: false,
+      defaultConstraints: 'PRIMARY KEY AUTOINCREMENT');
   final VerificationMeta _descriptionMeta =
       const VerificationMeta('description');
   @override
-  late final GeneratedTextColumn description = _constructDescription();
-  GeneratedTextColumn _constructDescription() {
-    return GeneratedTextColumn(
-      'desc',
-      $tableName,
-      true,
-    );
-  }
-
+  late final GeneratedColumn<String?> description = GeneratedColumn<String?>(
+      'desc', aliasedName, true,
+      type: const StringType(), requiredDuringInsert: false);
   @override
   List<GeneratedColumn> get $columns => [id, description];
   @override
-  $CategoriesTable get asDslTable => this;
+  String get aliasedName => _alias ?? 'categories';
   @override
-  String get $tableName => _alias ?? 'categories';
-  @override
-  final String actualTableName = 'categories';
+  String get actualTableName => 'categories';
   @override
   VerificationContext validateIntegrity(Insertable<Category> instance,
       {bool isInserting = false}) {
@@ -451,13 +425,13 @@ class $CategoriesTable extends Categories
   Set<GeneratedColumn> get $primaryKey => {id};
   @override
   Category map(Map<String, dynamic> data, {String? tablePrefix}) {
-    return Category.fromData(data, _db,
+    return Category.fromData(data,
         prefix: tablePrefix != null ? '$tablePrefix.' : null);
   }
 
   @override
   $CategoriesTable createAlias(String alias) {
-    return $CategoriesTable(_db, alias);
+    return $CategoriesTable(attachedDatabase, alias);
   }
 }
 

--- a/lib/src/database/database/mobile.dart
+++ b/lib/src/database/database/mobile.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 
-import 'package:moor/ffi.dart';
-import 'package:moor/moor.dart';
+import 'package:drift/native.dart';
+import 'package:drift/drift.dart';
 
 import 'package:path_provider/path_provider.dart' as paths;
 import 'package:path/path.dart' as p;
@@ -13,17 +13,17 @@ Database constructDb({bool logStatements = false}) {
     final executor = LazyDatabase(() async {
       final dataDir = await paths.getApplicationDocumentsDirectory();
       final dbFile = File(p.join(dataDir.path, 'db.sqlite'));
-      return VmDatabase(dbFile, logStatements: logStatements);
+      return NativeDatabase(dbFile, logStatements: logStatements);
     });
     return Database(executor);
   }
   if (Platform.isMacOS || Platform.isLinux) {
     final file = File('db.sqlite');
-    return Database(VmDatabase(file, logStatements: logStatements));
+    return Database(NativeDatabase(file, logStatements: logStatements));
   }
   // if (Platform.isWindows) {
   //   final file = File('db.sqlite');
   //   return Database(VMDatabase(file, logStatements: logStatements));
   // }
-  return Database(VmDatabase.memory(logStatements: logStatements));
+  return Database(NativeDatabase.memory(logStatements: logStatements));
 }

--- a/lib/src/database/database/web.dart
+++ b/lib/src/database/database/web.dart
@@ -1,4 +1,4 @@
-import 'package:moor/moor_web.dart';
+import 'package:drift/web.dart';
 
 import '../database.dart';
 

--- a/lib/src/database/db_utils.dart
+++ b/lib/src/database/db_utils.dart
@@ -1,4 +1,4 @@
-import 'package:moor/moor.dart';
+import 'package:drift/drift.dart';
 import 'package:undo/undo.dart';
 
 extension TableUtils on GeneratedDatabase {

--- a/lib/ui/common/add_category_dialog.dart
+++ b/lib/ui/common/add_category_dialog.dart
@@ -39,7 +39,7 @@ class _AddCategoryDialogState extends State<AddCategoryDialog> {
                   child: const Text('Add'),
                   style: ButtonStyle(
                     textStyle: MaterialStateProperty.all(
-                      TextStyle(color: Theme.of(context).accentColor),
+                      TextStyle(color: Theme.of(context).colorScheme.secondary),
                     ),
                   ),
                   onPressed: _addEntry,

--- a/lib/ui/common/categories_drawer.dart
+++ b/lib/ui/common/categories_drawer.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:moor_db_viewer/moor_db_viewer.dart';
+import 'package:drift_db_viewer/drift_db_viewer.dart';
 import 'package:moor_shared/src/database/database.dart';
 
 import '../../src/blocs/todo.dart';
@@ -20,7 +20,7 @@ class CategoriesDrawer extends StatelessWidget {
 
                 Navigator.of(context).push(
                   MaterialPageRoute(
-                    builder: (context) => MoorDbViewer(db),
+                    builder: (context) => DriftDbViewer(db),
                   ),
                 );
               },
@@ -54,10 +54,9 @@ class CategoriesDrawer extends StatelessWidget {
             children: <Widget>[
               TextButton(
                 child: const Text('Add category'),
-                // textColor: Theme.of(context).accentColor,
                 style: ButtonStyle(
                   textStyle: MaterialStateProperty.all(
-                    TextStyle(color: Theme.of(context).accentColor),
+                    TextStyle(color: Theme.of(context).colorScheme.secondary),
                   ),
                 ),
                 onPressed: () {
@@ -96,7 +95,8 @@ class _CategoryDrawerEntry extends StatelessWidget {
         title,
         style: TextStyle(
           fontWeight: FontWeight.bold,
-          color: isActive ? Theme.of(context).accentColor : Colors.black,
+          color:
+              isActive ? Theme.of(context).colorScheme.secondary : Colors.black,
         ),
       ),
       Padding(

--- a/lib/ui/home/screen.dart
+++ b/lib/ui/home/screen.dart
@@ -97,7 +97,7 @@ class HomeScreenState extends State<HomeScreen> {
                         ),
                         IconButton(
                           icon: Icon(Icons.send),
-                          color: Theme.of(context).accentColor,
+                          color: Theme.of(context).colorScheme.secondary,
                           onPressed: _createTodoEntry,
                         ),
                       ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,11 +12,11 @@ dependencies:
 
   # Dart
   cupertino_icons: ^1.0.3
-  moor: ^4.3.2
+  drift: ^1.0.0
   rxdart: ^0.27.1
   intl: ^0.17.0
 
-  # Also use the latest version.
+  # Flutter plugin to provide the native sqlite3 library on iOS, macOS and Android
   sqlite3_flutter_libs: ^0.5.0
 
   # Helper to find the database path on mobile
@@ -24,13 +24,12 @@ dependencies:
   path: ^1.8.0
   undo: ^1.4.0
 
-  moor_db_viewer: ^4.0.0
-  
+  drift_db_viewer: ^1.0.3
   bloc: ^7.0.0
   flutter_bloc: ^7.0.1
 
 dev_dependencies:
-  moor_generator: ^4.3.1
+  drift_dev: ^1.0.0
   build_runner: ^2.0.5
   build_web_compilers: ^3.0.0
   flutter_test:


### PR DESCRIPTION
- `moor` has [been renamed to](https://drift.simonbinder.eu/name/) `drift`, so I ran `flutter pub run moor_generator migrate` to patch references.
- Migrated from `moor_db_viewer` to `drift_db_viewer`
- Upgrade Gradle version and plugins used to build the Android App
- Add a note that some special setup is needed to run drift on Linux or Windows.
- Add a note that running `flutter run -d chrome` will not persist data as Flutter now uses a temporary profile.
- Fix usages of deprecated members.